### PR TITLE
my_profile corrected to get based on username instead of first

### DIFF
--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.get(username=request.auth.user))
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
# Description

Previous my_profile method was returning a user based on object.first, updated method to use object.get(username=request.auth.user)

Fixes #2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Acquire token for a valid user. Use token for auth and make get call to /profiles/my-profile. should return details of the current user token


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
